### PR TITLE
fix config service restart task name - restart_cfgm

### DIFF
--- a/fabfile/tasks/misc.py
+++ b/fabfile/tasks/misc.py
@@ -29,7 +29,7 @@ def detach_vrouter_node(*args):
         with settings(host_string=host_string):
             run("service supervisor-vrouter stop")
     execute("restart_control")
-    execute("restart_config")
+    execute("restart_cfgm")
 
 @task
 @roles('build')


### PR DESCRIPTION
config service restart function name incorrect in fab detach_vrouter_node task.
