### PR TITLE
Configuration format changes for some of the contrail software daemons

### DIFF
--- a/fabfile/tasks/upgrade.py
+++ b/fabfile/tasks/upgrade.py
@@ -139,6 +139,10 @@ def upgrade_control_node(rpm, *args):
             execute('backup_install_repo_node', host_string)
             execute('install_pkg_node', rpm, host_string)
             execute('create_install_repo_node', host_string)
+
+            # Migrate to new configuration .ini format, if necessary.
+            run("/opt/contrail/contrail_installer/contrail_config_templates/dns.conf.sh")
+            run("/opt/contrail/contrail_installer/contrail_config_templates/control-node.conf.sh")
             execute(upgrade)
             execute(upgrade_venv_packages)
             execute('upgrade_pkgs_node', host_string)
@@ -160,6 +164,8 @@ def upgrade_collector_node(rpm, *args):
             execute('backup_install_repo_node', host_string)
             execute('install_pkg_node', rpm, host_string)
             execute('create_install_repo_node', host_string)
+            run("/opt/contrail/contrail_installer/contrail_config_templates/qe.conf.sh")
+            run("/opt/contrail/contrail_installer/contrail_config_templates/collector.conf.sh")
             execute(upgrade)
             execute(upgrade_venv_packages)
             execute('upgrade_pkgs_node', host_string)
@@ -202,6 +208,7 @@ def upgrade_vrouter_node(rpm, *args):
             execute('backup_install_repo_node', host_string)
             execute('install_pkg_node', rpm, host_string)
             execute('create_install_repo_node', host_string)
+            run("/opt/contrail/contrail_installer/contrail_config_templates/vrouter.conf.sh")
             execute(upgrade)
             execute(upgrade_venv_packages)
             execute('setup_vrouter_node', host_string)


### PR DESCRIPTION
o control-node
o collector (vizd)
o dns
o query-engine
o vnswad (vrouter)

These daemons now take configuration in the standard .ini format.
Default configuration file is read off

/etc/contrail/control-node.conf
/etc/contrail/collector.conf
/etc/contrail/dns.conf
/etc/contrail/query-engine.conf
/etc/contrail/vrouter.conf

One can override the values from the config file through command line option
as well. e.g. --LOG.level=DEBUG, --DEFAULTS.hostip=1.2.3.4, etc.

Use --help to see various options available. Package also places the default
config file under /etc/contrail/.

When configuration changes are made, the process must be _restarted_ to
take effect.
