### PR TITLE
Fix the centos in-release upgrade, install and rabbitmq tasks.

### DIFF
--- a/fabfile/tasks/install.py
+++ b/fabfile/tasks/install.py
@@ -32,7 +32,7 @@ def install_pkg_all(deb):
 def install_pkg_node(pkg, *args):
     """Installs any rpm/deb in one node."""
     for host_string in args:
-        with settings(host_string=host_string):
+        with settings(host_string=host_string, warn_only=True):
             build = get_build()
             if build and build in pkg:
                 print "Package %s already installed in the node(%s)." % (pkg, host_string)

--- a/fabfile/tasks/rabbitmq.py
+++ b/fabfile/tasks/rabbitmq.py
@@ -96,13 +96,15 @@ def add_cfgm_to_rabbitmq_cluster():
     if detect_ostype() in ['Ubuntu']:
         run("rabbitmqctl cluster rabbit@%s rabbit@%s" % (cfgm1, this_cfgm))
     else:
-        run("rabbitmqctl join_cluster --ram rabbit@%s" % cfgm1)
+        run("rabbitmqctl join_cluster rabbit@%s" % cfgm1)
 
 @task
 @roles('cfgm')
 def verify_cluster_status():
     output = run("rabbitmqctl cluster_status")
     match = re.search("{running_nodes,\[(.*)\]}", output)
+    if not match:
+        return False
     clustered_nodes = match.group(1).split(',')
     clustered_nodes = [node.strip("'") for node in clustered_nodes]
 
@@ -126,8 +128,9 @@ def setup_rabbitmq_cluster():
         print "Single cfgm cluster, skipping rabbitmq cluster setup."
         return 
 
-    result = execute(verify_cluster_status)
-    if False not in result.values():
+    with settings(warn_only=True):
+        result = execute(verify_cluster_status)
+    if result and False not in result.values():
         print "RabbitMQ cluster is up and running; No need to cluster again."
         return
 

--- a/fabfile/tasks/upgrade.py
+++ b/fabfile/tasks/upgrade.py
@@ -40,7 +40,7 @@ def upgrade_zookeeper():
     run("supervisorctl -s http://localhost:9004 stop redis-config")
     run("supervisorctl -s http://localhost:9004 stop contrail-config-nodemgr")
     run("supervisorctl -s http://localhost:9004 stop ifmap")
-    if get_release() in RELEASES_WITH_ZOO_3_4_3:
+    if detect_ostype() in ['centos'] or get_release() in RELEASES_WITH_ZOO_3_4_3:
         run("supervisorctl -s http://localhost:9004 stop contrail-zookeeper")
     else:
         if "running" in run("service zookeeper status"):
@@ -57,7 +57,7 @@ def upgrade_zookeeper():
     execute("restore_zookeeper_config_node", env.host_string)
     execute("zoolink_node", env.host_string)
 
-    if get_release() in RELEASES_WITH_ZOO_3_4_3:
+    if detect_ostype() in ['centos'] or get_release() in RELEASES_WITH_ZOO_3_4_3:
         run("supervisorctl -s http://localhost:9004 start contrail-zookeeper")
     else:
         run("service zookeeper start")


### PR DESCRIPTION
1. Fix install_pkg_all task, as rpm query when it fails, the return code is 1 and if dpkg --info even it fail it retruns 0 ( handled with warn_only=Ture).
2. Should not use --ram option in centos during rabbitmqctl join_cluster.
3. In Centos, for all release the zookeeper service name is contrail-zookeeper.
