### PR TITLE
analytics upgrade issue

### DIFF
--- a/fabfile/tasks/services.py
+++ b/fabfile/tasks/services.py
@@ -51,11 +51,6 @@ def stop_control():
 def stop_collector():
     """stops the contrail collector services."""
     run('service supervisor-analytics stop')
-    run('service contrail-collector stop')
-    run('service contrail-opserver stop')
-    run('service contrail-qe stop')
-    run('service redis-query stop')
-    run('service redis-uve stop')
 
 @task
 @roles('compute')

--- a/fabfile/tasks/upgrade.py
+++ b/fabfile/tasks/upgrade.py
@@ -29,6 +29,9 @@ def fix_redis_uve_conf():
             run("sed 's/^slaveof/#&/' %s > %s.new" % (redis_uve_conf, redis_uve_conf))
             run("mv %s.new %s" % (redis_uve_conf, redis_uve_conf))
 
+        run('rm -f /etc/contrail/sentinel.conf')
+        run('rm -f /etc/contrail/supervisord_analytics_files/redis-sentinel.ini')
+
 @task
 @EXECUTE_TASK
 @roles('compute')
@@ -502,6 +505,7 @@ def upgrade_all(pkg):
     execute(create_install_repo)
     execute(check_and_stop_disable_qpidd_in_openstack)
     execute(check_and_stop_disable_qpidd_in_cfgm)
+    execute('stop_collector')
     execute(upgrade)
     with settings(warn_only=True):
         if get_release() in ['1.05']:
@@ -551,6 +555,7 @@ def upgrade_contrail(pkg):
         execute('setup_cfgm')
         execute('start_api_services')
         execute('upgrade_database', pkg)
+        execute('stop_collector')
         execute('upgrade_collector', pkg)
         execute('upgrade_openstack', pkg)
         execute('upgrade_control', pkg)


### PR DESCRIPTION
When an analytics node is upgraded, sentinel running in other analytics nodes [running R1.04] may trigger redis-uve failover, which would result in the addition of old keys in the upgraded analytics node (redis-uve). Fix: stop the analytics service before upgrade and remove sentinel.ini
