### PR TITLE
Fix the regexp to handle multiline running_nodes output/one line running...

### DIFF
--- a/fabfile/tasks/rabbitmq.py
+++ b/fabfile/tasks/rabbitmq.py
@@ -103,7 +103,7 @@ def add_cfgm_to_rabbitmq_cluster():
 @roles('cfgm')
 def verify_cluster_status():
     output = run("rabbitmqctl cluster_status")
-    running_nodes = re.compile("{running_nodes,\[(\S+)\]}", re.DOTALL)
+    running_nodes = re.compile(r"running_nodes,\[([^\]]*)")
     match = running_nodes.search(output)
     if not match:
         return False


### PR DESCRIPTION
Fix the regexp to handle 
1. multi-line running_nodes output (with existing regexp multi-line case is not handled.)
2. one line running_nodes output and 
3. partition cases
