### PR TITLE
Fix upgrade between 3.15 to 3.16

### DIFF
--- a/fabfile/tasks/upgrade.py
+++ b/fabfile/tasks/upgrade.py
@@ -222,7 +222,7 @@ def upgrade_compute_node(from_rel, pkg, *args, **kwargs):
                 if (getattr(env, 'interface_rename', True) and
                     detect_ostype() not in ['ubuntu', 'redhat']):
                     pkgs.append('contrail-interface-name')
-                if LooseVersion(from_rel) <= LooseVersion('3.2.14.0'):
+                if LooseVersion(from_rel) <= LooseVersion('3.2.15.0'):
                     dist, version, extra = get_linux_distro()
                     if version == '14.04':
                        if 'contrail-vrouter-3.13.0-40-generic' in pkgs:
@@ -239,6 +239,8 @@ def upgrade_compute_node(from_rel, pkg, *args, **kwargs):
                           pkgs.remove('contrail-vrouter-3.13.0-142-generic')
                        if 'contrail-vrouter-3.13.0-156-generic' in pkgs:
                           pkgs.remove('contrail-vrouter-3.13.0-156-generic')
+                       if 'contrail-vrouter-3.13.0-171-generic' in pkgs:
+                          pkgs.remove('contrail-vrouter-3.13.0-171-generic')
                        if 'contrail-vrouter-3.13.0-176-generic' in pkgs:
                           pkgs.remove('contrail-vrouter-3.13.0-176-generic')
                        pkgs.append('contrail-vrouter-3.13.0-176-generic')


### PR DESCRIPTION
Upgrade failed when it tries to install the unavailable package

2020-05-12 16:28:06:391276: [root@10.204.216.99] out:
2020-05-12 16:28:06:391363: [root@10.204.216.99] out: E: Package 'contrail-vrouter-3.13.0-171-generic' has no installation candidate
2020-05-12 16:28:06:391447: [root@10.204.216.99] out:
2020-05-12 16:28:06:391530: [root@10.204.216.99] out: Fatal error: local() encountered an error (return code 100) while executing 'DEBIAN_FRONTEND=noninteractive apt-get -y --force-yes -o Dpkg::Options::="--force-overwrite" -o Dpkg::Options::="--force-confnew" install contrail-vrouter-3.13.0-171-generic contrail-openstack-vrouter haproxy iproute contrail-vrouter-3.13.0-176-generic'